### PR TITLE
Improve documentation part 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,4 +15,7 @@ To build:
 -	trustObj, err := macOS.SecTrustCreateWithCertificates(certs, policies)
 ```
 3. Build normally with `go build Aqua-HTTP-Proxy.go` and `go build Aqua-IMAP-Proxy.go`.
-4. Inject the MacPorts Legacy Support library and https://trac.macports.org/ticket/66749#comment:2 to make the binary run on Legacy OS X.
+4. Build [MacPorts Legacy Support](https://github.com/macports/macports-legacy-support/blob/master/BUILDING.txt) on Snow Leopard.
+5. Build [wowfunhappy-legacy-support](https://github.com/Wowfunhappy/wowfunhappy-legacy-support) (contains fixes from https://trac.macports.org/ticket/66749#comment:2).
+6. Place these dylibs in `Package/Aqua\ Proxy/AquaProxy`
+7. Run `insert_dylib.sh` to inject the libraries.

--- a/Source Code/insert_dylib.sh
+++ b/Source Code/insert_dylib.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# insert_dylib needs to be in $PATH
+# https://github.com/tyilo/insert_dylib
+
 mkdir -p ../Package/Aqua\ Proxy/AquaProxy
 cd ../Package/Aqua\ Proxy/AquaProxy
 

--- a/Source Code/insert_dylib.sh
+++ b/Source Code/insert_dylib.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
-cd ~/Developer/AquaProxy/Package/Aqua\ Proxy/AquaProxy
+mkdir -p ../Package/Aqua\ Proxy/AquaProxy
+cd ../Package/Aqua\ Proxy/AquaProxy
 
 insert_dylib --inplace libWowfunhappyLegacySupport.dylib Aqua-HTTP-Proxy
 insert_dylib --inplace libMacportsLegacySupport.dylib Aqua-HTTP-Proxy


### PR DESCRIPTION
- Where to find `insert_dylib`, and change to a relative path for injection.
- Where to get the legacy support libraries.