### PR TITLE
Update Wowfunhappy.AquaProxy.Proxy.plist

### DIFF
--- a/Package/Aqua Proxy/LaunchAgents/Wowfunhappy.AquaProxy.Proxy.plist
+++ b/Package/Aqua Proxy/LaunchAgents/Wowfunhappy.AquaProxy.Proxy.plist
@@ -11,7 +11,7 @@
 
 	<key>ProgramArguments</key>
 	<array>
-		<string>/Library/AquaProxy/AquaProxy</string>
+		<string>/Library/AquaProxy/aquaproxy</string>
 	</array>
 
 	<key>StandardOutPath</key>


### PR DESCRIPTION
Use case sensitive naming of the binary to match exact file name and prevent errors on case sensitive file systems.

This should fix https://github.com/Wowfunhappy/AquaProxy/issues/6#issue-4413744155