### PR TITLE
Support other ports and HTTPS > HTTP redirect in the HTTPS handleMITMWithLogging

### DIFF
--- a/Source Code/http.go
+++ b/Source Code/http.go
@@ -1322,7 +1322,20 @@ func (p *Proxy) handleMITMWithLogging(tlsConn *tls.Conn, serverConn *tls.Conn, h
 					}
 					targetConfig.ServerName = targetURL.Host
 
-					targetConn, err := tls.Dial("tcp", targetURL.Host+":443", targetConfig)
+					var targetConn net.Conn
+					hostname := targetURL.Hostname()
+					port := targetURL.Port()
+					if (strings.HasSuffix(targetURL.Scheme, "s")) {
+						if port == "" {
+							port = "443"
+						}
+						targetConn, err = tls.Dial("tcp", hostname+":"+port, targetConfig)
+					} else {
+						if port == "" {
+							port = "80"
+						}
+						targetConn, err = net.Dial("tcp", hostname+":"+port)
+					}
 					if err != nil {
 						// Send error response to client
 						tlsConn.Write([]byte("HTTP/1.1 502 Bad Gateway\r\n\r\n"))


### PR DESCRIPTION
Since it has been some time since I touched Go, certain lines could be shortened here.
While both of these might not be useful in most cases, it was certainly useful when testing stuff.